### PR TITLE
fix mem leak when using keyed mutex with lots of non reusable keys.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ class Mutex {
             this._queue[key].shift()(this._dispatchNext.bind(this));
         } else {
             this._pending[key] = false;
+            delete this._pending[key];
+            delete this._queue[key];
         }
     }
 }


### PR DESCRIPTION
When using the mutex for locking a one time key the key stays in the _queue & _pending objects filling the memory with large keys.